### PR TITLE
TRIP-62641 Document sorted=false fast path on /ledger/posting/openPost

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -26,6 +26,18 @@ If you want the orderlines related to the order as well you can expand the API r
 
 ---
 
+### How can I make `/ledger/posting/openPost` faster on accounts with many postings?
+
+#### Answer:
+
+`GET /v2/ledger/posting/openPost` returns the open postings on an account as of a given date. By default the result is sorted by voucher (year and number), which becomes expensive on accounts that have a large number of postings.
+
+If you do not need the voucher ordering, add `sorted=false` to the request. You get the exact same set of open postings, only unordered, and the response is significantly faster on large accounts. For best performance, combine it with the `fields` parameter (see above) to limit the returned data, and with paging (`from` and `count`).
+
+Example: `GET /v2/ledger/posting/openPost?date=2026-12-31&accountId=123456&sorted=false&fields=id,date,amount,invoiceNumber&count=1000`
+
+---
+
 ### How can I correct the validation message “The unit price must be exclusive VAT since the unit price on the order is exclusive VAT.”
 
 #### Answer:

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # API changelog
 
+## 2.75.06 (2026-06-23)
+- Added new optional query parameter `sorted` to `GET /ledger/posting/openPost`.
+  - `true` (default) — open postings are returned ordered by voucher (year, then number). Existing callers see no change.
+  - `false` — returns the same set of open postings, unordered. Significantly faster on accounts with a large number of postings, since the sort is skipped. Recommended when reading large accounts where you do not depend on the voucher ordering.
+
 ## 2.75.05 (2026-05-15)
 - Added new optional query parameter `addToInvoiceMode` to `PUT /order/{id}/:attach`. Controls which invoices receive the uploaded attachment.
   - `NEXT` (default) — only the next invoice. Legacy behavior; existing callers see no change.


### PR DESCRIPTION
## What

Documents the new optional `sorted` query parameter on `GET /ledger/posting/openPost`:

- **changelog.md** — new `2.75.06` entry describing the parameter and its values.
- **FAQ.md** — a performance tip (placed next to the existing `fields` effectivity Q&A) showing how to use `sorted=false` to speed up the endpoint on large accounts.

## Why

`GET /ledger/posting/openPost` sorts the result by voucher by default, which is very expensive on accounts with a large number of open postings (some integrations see multi-minute responses). The backend now supports `sorted=false`, which returns the **same** set of open postings, unordered, on a fast path. The default (`sorted=true`) is unchanged, so existing callers are unaffected.

Backend change: Tripletex-AS/tripletex#9431 (live in prod since 2026-06-23). This docs PR lets API consumers discover and adopt the faster option.

## Note for the reviewer

The monolith `API_VERSION` constant is currently still `2.75.05` (the backend change did not bump it). I used `2.75.06 (2026-06-23)` as the next patch entry — please align the version / bump the constant to match the intended release if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)